### PR TITLE
fix: support older ruby version (2.5.1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,5 +26,5 @@ Metrics/AbcSize:
   Max: 25
 
 AllCops:
-  TargetRubyVersion: 2.5.5
+  TargetRubyVersion: 2.5.1
   DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - 2.5.1
   - 2.5.6
   - 2.6.4
 before_install: gem install bundler -v 2.1.0


### PR DESCRIPTION
Bulldog use ruby 2.5.1

```
adding /home/travis/build/petlove/turtle/vendor/bundle to cache
ruby.versions
$ ruby --version
before_install
0.53s$ gem install bundler -v 2.0.2
8.26s$ bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
Fetching gem metadata from https://rubygems.org/.........
Fetching https://github.com/petlove/aws-sns-configurator.git
Fetching https://github.com/petlove/aws-sqs-configurator.git
aws-sns-configurator-0.2.1 requires ruby version >= 2.5.5, which is incompatible
with the current version, ruby 2.5.1p57
The command "eval bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle} " failed. Retrying, 2 of 3.
Fetching gem metadata from https://rubygems.org/.........
aws-sns-configurator-0.2.1 requires ruby version >= 2.5.5, which is incompatible
with the current version, ruby 2.5.1p57
The command "eval bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle} " failed. Retrying, 3 of 3.
Fetching gem metadata from https://rubygems.org/.........
aws-sns-configurator-0.2.1 requires ruby version >= 2.5.5, which is incompatible
with the current version, ruby 2.5.1p57
The command "eval bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle} " failed 3 times.
The command "bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}" failed and exited with 5 during .
Your build has been stopped.
```